### PR TITLE
Fix revision error in tagged git URIs

### DIFF
--- a/recipes-sc-hsm-cardservice/sc-hsm-cardservice/sc-hsm-embedded_2.11.bb
+++ b/recipes-sc-hsm-cardservice/sc-hsm-cardservice/sc-hsm-embedded_2.11.bb
@@ -19,7 +19,9 @@ HOMEPAGE = "https://github.com/CardContact/sc-hsm-embedded"
 LICENSE = "BSD-3-Clause"
 LIC_FILES_CHKSUM = "file://COPYING;md5=55b854a477953696452f698a3af5de1c"
 
-SRC_URI = " git://github.com/CardContact/sc-hsm-embedded.git;protocol=https;tag=V2.11;branch=master"
+TAG := "${PV}"
+SRC_URI = " git://github.com/CardContact/sc-hsm-embedded.git;protocol=https;tag=V${TAG};branch=master"
+PV = "${TAG}+git${SRCPV}"
 
 SRC_URI:append = " \
 	file://0001-build-a-cardservice-library.patch;patch=1 \

--- a/recipes-trustx/cwrap/uid-wrapper_1.2.8.bb
+++ b/recipes-trustx/cwrap/uid-wrapper_1.2.8.bb
@@ -5,7 +5,9 @@ PR = "r0"
 
 LIC_FILES_CHKSUM = "file://${WORKDIR}/git/LICENSE;md5=d32239bcb673463ab874e80d47fae504"
 
-SRC_URI = "git://git.samba.org/uid_wrapper.git;protocol=https;tag=uid_wrapper-${PV};branch=master"
+TAG := "${PV}"
+SRC_URI = "git://git.samba.org/uid_wrapper.git;protocol=https;tag=uid_wrapper-${TAG};branch=master"
+PV = "${TAG}+git${SRCPV}"
 
 S = "${WORKDIR}/git"
 


### PR DESCRIPTION
Correctly sets PV using SRCPV and therefore fixing: ERROR: uid-wrapper-1.2.8-r0 do_fetch: Bitbake Fetcher Error:
	FetchError("Recipe uses a floating tag/branch without a
	fixed SRCREV yet doesn't call bb.fetch2.get_srcrev()
	(use SRCPV in PV for OE).", None)

Signed-off-by: Johannes Wiesboeck <johannes.wiesboeck@aisec.fraunhofer.de>