### PR TITLE
recipes-tss/tss2/ibmtss2: Drop support for TPM1.2

### DIFF
--- a/recipes-tss/tss2/ibmtss2_1331.bb
+++ b/recipes-tss/tss2/ibmtss2_1331.bb
@@ -25,12 +25,12 @@ LIBRARY_FLAGS = "\
 	-I. \
 	-fPIC \
 	-DTPM_TPM20 \
-	-DTPM_TPM12 \
 	-DTPM_INTERFACE_TYPE_DEFAULT=\"dev\" \
 "
 
 # overwrite compiler and compiler flags in makefile
 EXTRA_OEMAKE = "\
+	'--makefile=makefiletpm20' \
 	'CC = ${CC}' \
 	'CCLFLAGS = ${LIBRARY_FLAGS}' \
 "


### PR DESCRIPTION
On kirkstone compilation currently fails due to multiple definitions for the same symbol in two different files. These files are Commands.c and Commands12.c corresponding to TPM2.0 and TPM1.2 implementations respectively.

A simple fix is to disable TPM1.2 support for this version of ibmtss2. I would recommend bumping ibmtss2 to version 1.6.0 later in the kirkstone migration process which should fix this problem itself and then drop this version of ibmtss2. For now this is the lowest impact fix to get compilation going again.

Feel free to suggest better fixes, i'm out of ideas.

Attached Error Messages:

/opt/ws-yocto/out-x86-production/tmp/work/core2-64-poky-linux-musl/ibmtss2/1331-r0/recipe-sysroot-native/usr/bin/x86_64-poky-linux-musl/../../libexec/x86_64-poky-linux-musl/gcc/x86_64-poky-linux-musl/11.3.0/ld: Commands.o:/opt/ws-yocto/out-x86-production/tmp/work/core2-64-poky-linux-musl/ibmtss2/1331-r0/ibmtss2/utils/Commands.c:69: multiple definition of `in'; Commands12.o:/opt/ws-yocto/out-x86-production/tmp/work/core2-64-poky-linux-musl/ibmtss2/1331-r0/ibmtss2/utils/Commands12.c:46: first defined here

/opt/ws-yocto/out-x86-production/tmp/work/core2-64-poky-linux-musl/ibmtss2/1331-r0/recipe-sysroot-native/usr/bin/x86_64-poky-linux-musl/../../libexec/x86_64-poky-linux-musl/gcc/x86_64-poky-linux-musl/11.3.0/ld: Commands.o:/opt/ws-yocto/out-x86-production/tmp/work/core2-64-poky-linux-musl/ibmtss2/1331-r0/ibmtss2/utils/Commands.c:70: multiple definition of `out'; Commands12.o:/opt/ws-yocto/out-x86-production/tmp/work/core2-64-poky-linux-musl/ibmtss2/1331-r0/ibmtss2/utils/Commands12.c:47: first defined here