### PR TITLE
Build cml using externalsrc

### DIFF
--- a/images/trustx-signing.inc
+++ b/images/trustx-signing.inc
@@ -2,7 +2,7 @@ SCRIPT_DIR = "${TOPDIR}/../trustme/build"
 
 CFG_OVERLAY_DIR = "${SCRIPT_DIR}/config_overlay"
 CONFIG_CREATOR_DIR = "${SCRIPT_DIR}/config_creator"
-PROTO_FILE_DIR = "${TOPDIR}/../trustme/cml/daemon"
+PROTO_FILE_DIR = "${WORKDIR}/recipe-sysroot/${includedir}/proto"
 PROVISIONING_DIR = "${SCRIPT_DIR}/device_provisioning"
 ENROLLMENT_DIR = "${PROVISIONING_DIR}/oss_enrollment"
 TEST_CERT_DIR = "${TOPDIR}/test_certificates"

--- a/recipes-trustx/cmld/cml-common.inc
+++ b/recipes-trustx/cmld/cml-common.inc
@@ -11,6 +11,17 @@ SRC_URI = "git://github.com/gyroidos/cml.git;branch=${BRANCH};protocol=https"
 
 S = "${WORKDIR}/git"
 
+# Determine if a local checkout of the cml repo is available.
+# If so, build using externalsrc.
+# If not, build from git.
+python () {
+    cml_dir = d.getVar('TOPDIR', True) + "/../trustme/cml"
+    if os.path.isdir(cml_dir):
+        d.setVar('EXTERNALSRC', cml_dir)
+        d.setVar('EXTERNALSRC_BUILD', cml_dir)
+}
+inherit externalsrc
+
 INSANE_SKIP:${PN} = "ldflags"
 
 do_configure () {

--- a/recipes-trustx/cmld/cml-common.inc
+++ b/recipes-trustx/cmld/cml-common.inc
@@ -1,0 +1,18 @@
+LICENSE = "GPLv2"
+LIC_FILES_CHKSUM = "file://${S}/COPYING;md5=b234ee4d69f5fce4486a80fdaf4a4263"
+
+BRANCH = "dunfell"
+SRCREV = "${AUTOREV}"
+
+PVBASE := "${PV}"
+PV = "${PVBASE}+${SRCPV}"
+
+SRC_URI = "git://github.com/gyroidos/cml.git;branch=${BRANCH};protocol=https"
+
+S = "${WORKDIR}/git"
+
+INSANE_SKIP:${PN} = "ldflags"
+
+do_configure () {
+    :
+}

--- a/recipes-trustx/cmld/cmld_git.bb
+++ b/recipes-trustx/cmld/cmld_git.bb
@@ -35,7 +35,7 @@ do_install () {
     install -m 0755 ${S}/rattestation/rattestation ${D}${sbindir}/
     install -d ${D}/${libdir}
     install -m 0755 ${S}/common/libcommon_full.a ${D}${libdir}/
-    install -d 0755 ${D}/${includedir}/common
+    install -d ${D}/${includedir}/common
     install -m 0644 ${S}/common/*.h ${D}${includedir}/common
 }
 

--- a/recipes-trustx/cmld/cmld_git.bb
+++ b/recipes-trustx/cmld/cmld_git.bb
@@ -1,23 +1,7 @@
-LICENSE = "GPLv2"
-LIC_FILES_CHKSUM = "file://${WORKDIR}/git/COPYING;md5=b234ee4d69f5fce4486a80fdaf4a4263"
-
-BRANCH = "dunfell"
-SRCREV = "${AUTOREV}"
-
-PVBASE := "${PV}"
-PV = "${PVBASE}+${SRCPV}"
-
-# upstream repository comment out for development and use local fork below
-SRC_URI = "git://github.com/gyroidos/cml.git;branch=${BRANCH}"
-
-# uncomment this an replay user/path to your local fork for development
-#SRC_URI = "git:///home/<user>/cml/;protocol=file;branch=wip"
-
-S = "${WORKDIR}/git/"
+require recipes-trustx/cmld/cml-common.inc
 
 PACKAGES =+ "control scd tpm2d rattestation"
 
-INSANE_SKIP_${PN} = "ldflags"
 INSANE_SKIP_scd = "ldflags"
 INSANE_SKIP_tpm2d = "ldflags"
 INSANE_SKIP_control = "ldflags"
@@ -30,10 +14,6 @@ EXTRA_OEMAKE += "TRUSTME_SCHSM=${TRUSTME_SCHSM}"
 EXTRA_OEMAKE += "DEVELOPMENT_BUILD=${DEVELOPMENT_BUILD}"
 EXTRA_OEMAKE += "CC_MODE=${CC_MODE}"
 
-do_configure () {
-    :
-}
-
 do_compile () {
     oe_runmake -C daemon
     oe_runmake -C control
@@ -45,18 +25,18 @@ do_compile () {
 }
 
 do_install () {
-    install -d ${D}${sbindir}/
-    install -d ${D}${sysconfdir}/init.d
-    install -m 0755 ${S}daemon/cmld ${D}${sbindir}/
-    install -m 0755 ${S}control/control ${D}${sbindir}/
-    install -m 0755 ${S}scd/scd ${D}${sbindir}/
-    install -m 0755 ${S}tpm2d/tpm2d ${D}${sbindir}/
-    install -m 0755 ${S}tpm2_control/tpm2_control ${D}${sbindir}/
-    install -m 0755 ${S}rattestation/rattestation ${D}${sbindir}/
-    install -d ${D}${libdir}
-    install -m 0755 ${S}common/libcommon_full.a ${D}${libdir}/
-    install -d 0755 ${D}${includedir}/common
-    install -m 0644 ${S}common/*.h ${D}${includedir}/common
+    install -d ${D}/${sbindir}/
+    install -d ${D}/${sysconfdir}/init.d
+    install -m 0755 ${S}/daemon/cmld ${D}${sbindir}/
+    install -m 0755 ${S}/control/control ${D}${sbindir}/
+    install -m 0755 ${S}/scd/scd ${D}${sbindir}/
+    install -m 0755 ${S}/tpm2d/tpm2d ${D}${sbindir}/
+    install -m 0755 ${S}/tpm2_control/tpm2_control ${D}${sbindir}/
+    install -m 0755 ${S}/rattestation/rattestation ${D}${sbindir}/
+    install -d ${D}/${libdir}
+    install -m 0755 ${S}/common/libcommon_full.a ${D}${libdir}/
+    install -d 0755 ${D}/${includedir}/common
+    install -m 0644 ${S}/common/*.h ${D}${includedir}/common
 }
 
 RDEPENDS_scd += "cmld openssl"

--- a/recipes-trustx/cmld/cmld_git.bb
+++ b/recipes-trustx/cmld/cmld_git.bb
@@ -37,6 +37,13 @@ do_install () {
     install -m 0755 ${S}/common/libcommon_full.a ${D}${libdir}/
     install -d ${D}/${includedir}/common
     install -m 0644 ${S}/common/*.h ${D}${includedir}/common
+
+    install -d ${D}/${includedir}/proto
+    install -m 0644 ${S}/daemon/*.proto ${D}${includedir}/proto
+    if [ "y" = "${CC_MODE}" ]; then
+        # if building cc_mode override files with respective cc_mode version
+        install -m 0644 ${S}/daemon/cc_mode/*.proto ${D}${includedir}/proto
+    fi
 }
 
 RDEPENDS_scd += "cmld openssl"

--- a/recipes-trustx/service/service-static_git.bb
+++ b/recipes-trustx/service/service-static_git.bb
@@ -1,26 +1,12 @@
-LICENSE = "GPLv2"
-LIC_FILES_CHKSUM = "file://${WORKDIR}/git/COPYING;md5=b234ee4d69f5fce4486a80fdaf4a4263"
+require recipes-trustx/cmld/cml-common.inc
 
-BRANCH = "dunfell"
-SRCREV = "${AUTOREV}"
 
-PVBASE := "${PV}"
-PV = "${PVBASE}+${SRCPV}"
 
-SRC_URI = "git://github.com/gyroidos/cml.git;branch=${BRANCH}"
-
-S = "${WORKDIR}/git/"
-
-INSANE_SKIP_${PN} = "ldflags"
 
 DEPENDS = "protobuf-c-native protobuf-c protobuf-c-text"
 
 FILES_${PN} += "${base_sbindir}"
 INHIBIT_PACKAGE_STRIP = "1"
-
-do_configure () {
-        :
-}
 
 do_compile () {
         oe_runmake -C service service-static
@@ -29,7 +15,7 @@ do_compile () {
 
 do_install () {
         :
-	install -d ${D}${base_sbindir}/
-	install -m 0755 ${S}service/cml-service-container ${D}${base_sbindir}/
-	install -m 0755 ${S}service/exec_cap_systime ${D}${base_sbindir}/
+	install -d ${D}/${base_sbindir}/
+	install -m 0755 ${S}/service/cml-service-container ${D}${base_sbindir}/
+	install -m 0755 ${S}/service/exec_cap_systime ${D}${base_sbindir}/
 }

--- a/recipes-trustx/service/service_git.bb
+++ b/recipes-trustx/service/service_git.bb
@@ -1,15 +1,7 @@
-LICENSE = "GPLv2"
-LIC_FILES_CHKSUM = "file://${WORKDIR}/git/COPYING;md5=b234ee4d69f5fce4486a80fdaf4a4263"
-
-BRANCH = "dunfell"
-SRCREV = "${AUTOREV}"
+require recipes-trustx/cmld/cml-common.inc
 
 FILESEXTRAPATHS_prepend := "${THISDIR}/files:"
 
-PVBASE := "${PV}"
-PV = "${PVBASE}+${SRCPV}"
-
-SRC_URI = "git://github.com/gyroidos/cml.git;branch=${BRANCH}"
 SRC_URI_append = "\
 	file://ssig_pki_generator.conf \
 	file://openssl-dockerlocal-rootca.cnf \
@@ -17,11 +9,8 @@ SRC_URI_append = "\
 	file://openssl-dockerlocal-ssig.cnf \
 "
 
-S = "${WORKDIR}/git/"
-
 PACKAGES =+ "converter"
 
-INSANE_SKIP_${PN} = "ldflags"
 INSANE_SKIP_converter = "ldflags"
 
 DEPENDS = "protobuf-c-native protobuf-c protobuf-c-text libtar zlib openssl"
@@ -33,10 +22,6 @@ SCRIPT_DIR = "${TOPDIR}/../trustme/build"
 PROVISIONING_DIR = "${SCRIPT_DIR}/device_provisioning"
 ENROLLMENT_DIR = "${PROVISIONING_DIR}/oss_enrollment"
 
-do_configure () {
-        :
-}
-
 
 do_compile () {
         oe_runmake -C service all
@@ -45,10 +30,10 @@ do_compile () {
 
 do_install () {
         :
-	install -d ${D}${base_sbindir}/
-	install -m 0755 ${S}service/cml-service-container ${D}${base_sbindir}/
-	install -d ${D}${bindir}/
-	install -m 0755 ${S}converter/converter ${D}${bindir}/
+	install -d ${D}/${base_sbindir}/
+	install -m 0755 ${S}/service/cml-service-container ${D}${base_sbindir}/
+	install -d ${D}/${bindir}/
+	install -m 0755 ${S}/converter/converter ${D}${bindir}/
 
 	install -d ${D}/pki_generator
 	install -d ${D}/pki_generator/config_creator
@@ -60,7 +45,7 @@ do_install () {
 	install -m 0600 ${WORKDIR}/openssl-dockerlocal-ssig.cnf ${D}/pki_generator
 
 	mkdir -p ${DEPLOY_DIR_IMAGE}/proto
-	cp ${S}daemon/*.proto ${DEPLOY_DIR_IMAGE}/proto
+	cp ${S}/daemon/*.proto ${DEPLOY_DIR_IMAGE}/proto
 }
 
 RDEPENDS_converter += "bash openssl libtar zlib curl squashfs-tools libgcc"


### PR DESCRIPTION
This PR makes a set of changes to support building the cml related recipes from the local checkout, while maintaining the ability to build from git if the checkout is missing.

The changes are:
1. Refactor the cml related recipes (cmld, service, service-static) to obtain their source information from one common include (cml-common.inc).
2. Fix errors due to missing '/' in paths.
3. Conditionally set EXTERNALSRC(_BUILD) in cml-common.inc depending on the existence of the cml repo checkout.
4. Install cml protobuf files to the sysroot to be obtained by trustx-signing. This is required if cmld is build from git and no checkout is available, thus breaking the old path to the protobuf file.