### PR TITLE
recipes-trustx/*: Build cml-related recipes out-of-tree

### DIFF
--- a/recipes-trustx/cmld/cml-common.inc
+++ b/recipes-trustx/cmld/cml-common.inc
@@ -11,6 +11,8 @@ SRC_URI = "git://github.com/gyroidos/cml.git;branch=${BRANCH};protocol=https"
 
 S = "${WORKDIR}/git"
 
+DEPENDS:append = " rsync-native"
+
 # Determine if a local checkout of the cml repo is available.
 # If so, build using externalsrc.
 # If not, build from git.
@@ -18,7 +20,6 @@ python () {
     cml_dir = d.getVar('TOPDIR', True) + "/../trustme/cml"
     if os.path.isdir(cml_dir):
         d.setVar('EXTERNALSRC', cml_dir)
-        d.setVar('EXTERNALSRC_BUILD', cml_dir)
 }
 inherit externalsrc
 
@@ -26,4 +27,16 @@ INSANE_SKIP:${PN} = "ldflags"
 
 do_configure () {
     :
+}
+
+# The poor man's out-of-source build
+# We require cmld and service* to be built using dfferent variants of libc
+# for container and host builds (e.g. glibc and musl). Build in-source would
+# poison the source directory with artifacts compiled with another libc, thus
+# we need to keep the source directory clean and copy the sources to the build
+# directory first.
+do_compile:prepend () {
+    if [ -n "${EXTERNALSRC}" ]; then
+        rsync -lr --exclude="oe-logs" --exclude="oe-workdir" "${S}/" "${B}"
+    fi
 }

--- a/recipes-trustx/cmld/cmld_git.bb
+++ b/recipes-trustx/cmld/cmld_git.bb
@@ -27,14 +27,14 @@ do_compile () {
 do_install () {
     install -d ${D}/${sbindir}/
     install -d ${D}/${sysconfdir}/init.d
-    install -m 0755 ${S}/daemon/cmld ${D}/${sbindir}/
-    install -m 0755 ${S}/control/control ${D}/${sbindir}/
-    install -m 0755 ${S}/scd/scd ${D}/${sbindir}/
-    install -m 0755 ${S}/tpm2d/tpm2d ${D}/${sbindir}/
-    install -m 0755 ${S}/tpm2_control/tpm2_control ${D}/${sbindir}/
-    install -m 0755 ${S}/rattestation/rattestation ${D}/${sbindir}/
+    install -m 0755 ${B}/daemon/cmld ${D}/${sbindir}/
+    install -m 0755 ${B}/control/control ${D}/${sbindir}/
+    install -m 0755 ${B}/scd/scd ${D}/${sbindir}/
+    install -m 0755 ${B}/tpm2d/tpm2d ${D}/${sbindir}/
+    install -m 0755 ${B}/tpm2_control/tpm2_control ${D}/${sbindir}/
+    install -m 0755 ${B}/rattestation/rattestation ${D}/${sbindir}/
     install -d ${D}/${libdir}
-    install -m 0755 ${S}/common/libcommon_full.a ${D}/${libdir}/
+    install -m 0755 ${B}/common/libcommon_full.a ${D}/${libdir}/
     install -d ${D}/${includedir}/common
     install -m 0644 ${S}/common/*.h ${D}/${includedir}/common
 

--- a/recipes-trustx/service/service-static_git.bb
+++ b/recipes-trustx/service/service-static_git.bb
@@ -16,6 +16,6 @@ do_compile () {
 do_install () {
         :
 	install -d ${D}/${base_sbindir}/
-	install -m 0755 ${S}/service/cml-service-container ${D}${base_sbindir}/
-	install -m 0755 ${S}/service/exec_cap_systime ${D}${base_sbindir}/
+	install -m 0755 ${B}/service/cml-service-container ${D}${base_sbindir}/
+	install -m 0755 ${B}/service/exec_cap_systime ${D}${base_sbindir}/
 }

--- a/recipes-trustx/service/service_git.bb
+++ b/recipes-trustx/service/service_git.bb
@@ -31,9 +31,9 @@ do_compile () {
 do_install () {
         :
 	install -d ${D}/${base_sbindir}/
-	install -m 0755 ${S}/service/cml-service-container ${D}/${base_sbindir}/
+	install -m 0755 ${B}/service/cml-service-container ${D}/${base_sbindir}/
 	install -d ${D}/${bindir}/
-	install -m 0755 ${S}/converter/converter ${D}${bindir}/
+	install -m 0755 ${B}/converter/converter ${D}${bindir}/
 
 	install -d ${D}/pki_generator
 	install -d ${D}/pki_generator/config_creator


### PR DESCRIPTION
We require cmld and service* to be built using dfferent variants of libc for container and host builds (e.g. glibc and musl). Build in-source poisons the source directory with artifacts compiled with another libc and thus breaks the build if building glibc containers. Thus, we need to keep the source directory clean and copy the sources to the build directory first.