### PR TITLE
linux-rolling-stable: Change to new syntax

### DIFF
--- a/recipes-kernel/linux/linux-rolling-stable_git.bb
+++ b/recipes-kernel/linux/linux-rolling-stable_git.bb
@@ -11,7 +11,7 @@ KERNEL_VERSION_SANITY_SKIP="1"
 
 SRCREV_machine ?= "${AUTOREV}"
 
-FILESEXTRAPATHS_prepend := "${THISDIR}/linux-vanilla:"
+FILESEXTRAPATHS:prepend := "${THISDIR}/linux-vanilla:"
 SRC_URI += "\
 	file://shiftfs-v6.2/0001-UBUNTU-SAUCE-shiftfs-uid-gid-shifting-bind-mount.patch \
 	file://shiftfs-v6.2/0002-UBUNTU-SAUCE-shiftfs-rework-and-extend.patch \


### PR DESCRIPTION
This commit adapts the linux-rolling-stable recipe to use the kirkstone syntax for prepending.