### PR TITLE
recipes-poky/busybox: Disable automatic gettys

### DIFF
--- a/recipes-poky/busybox/busybox-inittab_%.bbappend
+++ b/recipes-poky/busybox/busybox-inittab_%.bbappend
@@ -1,1 +1,3 @@
 FILESEXTRAPATHS:append := '${@bb.utils.contains("INITRAMFS_IMAGE", [ 'trustx-cml-initramfs' ], ":${THISDIR}/${PN}", "",d)}'
+
+SYSVINIT_ENABLED_GETTYS := ""


### PR DESCRIPTION
Automatically spawned gettys can intefere with some GyroidOS builds. Therefore, this commit  sets
SYSVINIT_ENABLED_GETTYS="" to remove gettys enabled by Yocto / Poky.