### PR TITLE
local.conf: Install btrfs programs

### DIFF
--- a/conf/templates/default/local.conf.sample
+++ b/conf/templates/default/local.conf.sample
@@ -26,7 +26,7 @@ BB_DISKMON_DIRS ??= "\
 PACKAGECONFIG:append:pn-qemu-native = " sdl"
 PACKAGECONFIG:append:pn-qemu-system-native = " sdl"
 PACKAGECONFIG:append:pn-nativesdk-qemu = " sdl"
-PACKAGECONFIG:pn-btrfs-tools = ""
+PACKAGECONFIG:pn-btrfs-tools = "programs"
 
 FETCHCMD_wget = "/usr/bin/env wget -t 2 -T 30 --passive-ftp --no-check-certificate"
 KERNEL_DEPLOYSUBDIR = "cml-kernel"


### PR DESCRIPTION
With the current config, mkfs.btrfs is not installed on kirkstone. Install it by enabling "programs" for btrfs-tools.