### PR TITLE
recipes-kernel/linux/linux-gyroidos: speed up do_bundle_initramfs

### DIFF
--- a/recipes-kernel/linux/linux-gyroidos.inc
+++ b/recipes-kernel/linux/linux-gyroidos.inc
@@ -11,6 +11,7 @@ DEPENDS += "squashfs-tools-native openssl-native"
 MODULE_IMAGE_SUFFIX = "squashfs"
 
 EXTRA_OEMAKE += " INSTALL_MOD_STRIP=1"
+KERNEL_EXTRA_ARGS:prepend = "${PARALLEL_MAKE} "
 
 KERNEL_MODULE_SIG_KEY ?= ""
 KERNEL_SYSTEM_TRUSTED_KEYS ?= ""


### PR DESCRIPTION
Currently upstream is being worked on the bug: bugzilla 15059 [https://bugzilla.yoctoproject.org/show_bug.cgi?id=15059] For kirkstone there is no fix yet and only a partial fix is in master: "kernel: improve initramfs bundle processing time" [01f0a371b139d35a6f6f39fdd96f0d1a796684d7]

Our workaround activates the parallel make in KERNEL_EXTRA_ARGS having the same effect as the upstream partial fix: