### PR TITLE
recipes-poky/pv: added bbappend with patch for foreground operation

### DIFF
--- a/recipes-poky/pv/pv/0001-pv-display-handle-error-of-tcgetpgrp-in-pv_in_foregr.patch
+++ b/recipes-poky/pv/pv/0001-pv-display-handle-error-of-tcgetpgrp-in-pv_in_foregr.patch
@@ -1,0 +1,38 @@
+From c5cd932fb08e7ce90cdbf9ae6c5cc7e65ac0738e Mon Sep 17 00:00:00 2001
+From: =?UTF-8?q?Michael=20Wei=C3=9F?= <michael.weiss@aisec.fraunhofer.de>
+Date: Tue, 9 May 2023 20:00:26 +0200
+Subject: [PATCH] pv/display: handle error of tcgetpgrp() in pv_in_foreground()
+MIME-Version: 1.0
+Content-Type: text/plain; charset=UTF-8
+Content-Transfer-Encoding: 8bit
+
+Show pv progress bar even if no terminal is set, e.g., in a busybox
+init script. The description of pv_in_forground() states it will
+return true "if we aren't outputting to a terminal". However, this
+is not the case since tcgetpgrg() will return an error and set ERRNO
+to ENOTTY if the output fd is not an tty. We now handle this error
+correctly and pv_in_foreground() returns also true in that case.
+
+Signed-off-by: Michael Weiß <michael.weiss@aisec.fraunhofer.de>
+---
+ src/pv/display.c | 4 ++++
+ 1 file changed, 4 insertions(+)
+
+diff --git a/src/pv/display.c b/src/pv/display.c
+index aff643b..8d1f4c9 100644
+--- a/src/pv/display.c
++++ b/src/pv/display.c
+@@ -48,6 +48,10 @@ bool pv_in_foreground(void)
+ 
+ 	our_process_group = getpgrp();
+ 	tty_process_group = tcgetpgrp(STDERR_FILENO);
++
++	if (tty_process_group == -1 && errno == ENOTTY)
++		return true;
++
+ 	if (our_process_group == tty_process_group)
+ 		return true;
+ 
+-- 
+2.30.2
+

--- a/recipes-poky/pv/pv_%.bbappend
+++ b/recipes-poky/pv/pv_%.bbappend
@@ -1,0 +1,3 @@
+FILESEXTRAPATHS:prepend := "${THISDIR}/${PN}:"
+
+SRC_URI += "file://0001-pv-display-handle-error-of-tcgetpgrp-in-pv_in_foregr.patch"


### PR DESCRIPTION
Current pv version does not display any output if invoked without a tty terminal present for current process. This is also the case if invoked by busybox init script. The patch solves this. see "pv Stopped Working in the Background #55"
	(https://github.com/a-j-wood/pv/issues/55)