### PR TITLE
conf/multiconfig/container_qemuarm*: set empty KERNEL_DEVICETREE

### DIFF
--- a/conf/multiconfig/container_qemuarm.inc
+++ b/conf/multiconfig/container_qemuarm.inc
@@ -20,6 +20,8 @@ PREFERRED_PROVIDER_virtual/kernel = "linux-dummy"
 PREFERRED_PROVIDER_virtual/kernel:gyroidos-core = "linux-dummy"
 PREFERRED_PROVIDER_virtual/kernel:linuxstdbase = "linux-dummy"
 
+KERNEL_DEVICETREE = ""
+
 IMAGE_FSTYPES = "cpio.gz ext4"
 
 # Possible provider: cacao-initial-native and jamvm-initial-native

--- a/conf/multiconfig/container_qemuarm64.inc
+++ b/conf/multiconfig/container_qemuarm64.inc
@@ -20,6 +20,8 @@ PREFERRED_PROVIDER_virtual/kernel = "linux-dummy"
 PREFERRED_PROVIDER_virtual/kernel:gyroidos-core = "linux-dummy"
 PREFERRED_PROVIDER_virtual/kernel:linuxstdbase = "linux-dummy"
 
+KERNEL_DEVICETREE = ""
+
 IMAGE_FSTYPES = "cpio.gz ext4"
 
 # Possible provider: cacao-initial-native and jamvm-initial-native


### PR DESCRIPTION
Since on some arm build variants, e.g., raspberrypi, the variable KERNEL_DEVICETREE needs to be present, otherwise parsing errors may occur. Thus, we clear that variable. The container multiconfig uses a dummy kernel and no device tree should be added to the container image anyway.