### PR TITLE
recipes-poky/base-files: use ext4fs for containers in fstab

### DIFF
--- a/recipes-poky/base-files/base-files/fstab
+++ b/recipes-poky/base-files/base-files/fstab
@@ -15,4 +15,4 @@ LABEL=trustme        /mnt                 ext4       nosuid,nodev,noexec   0  0
 /mnt/modules.img     /lib/modules         squashfs   loop,nosuid,nodev,noexec 0  0
 /mnt/firmware.img    /lib/firmware        squashfs   loop,nosuid,nodev,noexec 0  0
 
-LABEL=containers     /data/cml/containers btrfs      nosuid,nodev,noexec,nofail 0  0
+LABEL=containers     /data/cml/containers ext4       nosuid,nodev,noexec,nofail 0  0


### PR DESCRIPTION
Instead of btrfs make use of ext4 container storage image. This should help to make Jenkins tests more stable against killed qemu instances.