### PR TITLE
recipes-kernel/linux/linux-rolling-stable: variable syntax fixed

### DIFF
--- a/recipes-kernel/linux/linux-rolling-stable_git.bb
+++ b/recipes-kernel/linux/linux-rolling-stable_git.bb
@@ -20,5 +20,5 @@ DEPENDS += "elfutils-native"
 
 COMPATIBLE_MACHINE = "${MACHINE}"
 
-KBUILD_DEFCONFIG_genericx86-64 = "x86_64_defconfig"
+KBUILD_DEFCONFIG:genericx86-64 = "x86_64_defconfig"
 KCONFIG_MODE="--alldefconfig"


### PR DESCRIPTION
Fixed the syntax for declaring the machine specific variable which selects the kernel default config.