### PR TITLE
images/trustx-cml-firmware: Replace rmdir with rm -rf

### DIFF
--- a/images/trustx-cml-firmware.bb
+++ b/images/trustx-cml-firmware.bb
@@ -24,8 +24,8 @@ cleanup_root() {
 	rm -rf ${IMAGE_ROOTFS}/etc
 	rm -rf ${IMAGE_ROOTFS}/run
 	rm -rf ${IMAGE_ROOTFS}/var
-	rmdir ${IMAGE_ROOTFS}/lib/firmware
-	rmdir ${IMAGE_ROOTFS}/lib
+	rm -rf ${IMAGE_ROOTFS}/lib/firmware
+	rm -rf ${IMAGE_ROOTFS}/lib
 }
 
 ROOTFS_POSTPROCESS_COMMAND:append = " move_firmware; "


### PR DESCRIPTION
When not building from scratch but after the image has already been built once these rmdirs fail because of non-existent directories. This is fixed by also using rm -rf as this ignores non-existent directories silently.