### PR TITLE
recipes-kernel/linux/linux-rolling-stable: sanitize packaging

### DIFF
--- a/recipes-kernel/linux/linux-rolling-stable_git.bb
+++ b/recipes-kernel/linux/linux-rolling-stable_git.bb
@@ -1,6 +1,8 @@
 inherit kernel
 require recipes-kernel/linux/linux-yocto.inc
 
+HOMEPAGE = "https://www.kernel.org"
+
 SRC_URI = "git://git.kernel.org/pub/scm/linux/kernel/git/stable/linux.git;protocol=git;name=machine;branch=linux-rolling-stable"
 
 LIC_FILES_CHKSUM = "file://COPYING;md5=6bc538ed5bd9a7fc9398086aedcd7e46"
@@ -13,7 +15,7 @@ SRCREV_machine ?= "${AUTOREV}"
 
 FILESEXTRAPATHS:prepend := "${THISDIR}/linux-vanilla:"
 
-PVBASE := "${PV}"
+PVBASE := "1.0"
 PV = "${PVBASE}+${SRCPV}"
 
 DEPENDS += "elfutils-native"

--- a/recipes-kernel/linux/linux-vanilla_%.bbappend
+++ b/recipes-kernel/linux/linux-vanilla_%.bbappend
@@ -1,1 +1,3 @@
 include linux-gyroidos.inc
+
+LINUX_VERSION_EXTENSION = "-gyroidos"


### PR DESCRIPTION
Set PV from git to 1.0, to allow generated package also be installed on debian. Set homepage to kernel.org. Set LINUX_VERSION_EXTENSION to "-gyroidos".