### PR TITLE
recipes-trustx/service/service-static_git.bb: Update binary name

### DIFF
--- a/recipes-trustx/service/service-static_git.bb
+++ b/recipes-trustx/service/service-static_git.bb
@@ -16,6 +16,6 @@ do_compile () {
 do_install () {
         :
 	install -d ${D}/${base_sbindir}/
-	install -m 0755 ${B}/service/cml-service-container ${D}${base_sbindir}/
+	install -m 0755 ${B}/service/cml-service-container-static ${D}${base_sbindir}/
 	install -m 0755 ${B}/service/exec_cap_systime ${D}${base_sbindir}/
 }


### PR DESCRIPTION
For static builds 'cml-service-container' has been renamed to 'cml-service-container-static'.
s. https://github.com/gyroidos/cml/pull/414