### PR TITLE
recipes-kernel/linux/linux-rolling-stable: allow to set LINUX_VERSION

### DIFF
--- a/recipes-kernel/linux/linux-rolling-stable_git.bb
+++ b/recipes-kernel/linux/linux-rolling-stable_git.bb
@@ -7,16 +7,14 @@ SRC_URI = "git://git.kernel.org/pub/scm/linux/kernel/git/stable/linux.git;protoc
 
 LIC_FILES_CHKSUM = "file://COPYING;md5=6bc538ed5bd9a7fc9398086aedcd7e46"
 
+LINUX_VERSION ?= "1.0"
 LINUX_VERSION_EXTENSION = "-stable"
-
-KERNEL_VERSION_SANITY_SKIP="1"
 
 SRCREV_machine ?= "${AUTOREV}"
 
 FILESEXTRAPATHS:prepend := "${THISDIR}/linux-vanilla:"
 
-PVBASE := "1.0"
-PV = "${PVBASE}+${SRCPV}"
+PV = "${LINUX_VERSION}+${SRCPV}"
 
 DEPENDS += "elfutils-native"
 


### PR DESCRIPTION
Allow to set LINUX_VERSION as part of PV. Use version "1.0" as fallback if no LINUX_VERSION is provided by local.conf or auto.conf.