### PR TITLE
recipes-tss/openssl-tpm2-engine: Patch initializing variables

### DIFF
--- a/recipes-tss/openssl-tpm2-engine/openssl-tpm2-engine/0001-fix-uninitialized-variables-reported-by-gcc_4.0.1.patch
+++ b/recipes-tss/openssl-tpm2-engine/openssl-tpm2-engine/0001-fix-uninitialized-variables-reported-by-gcc_4.0.1.patch
@@ -1,0 +1,58 @@
+From 9f94d0cebed250a0f01c4b7dbe0b4d9be9be0e32 Mon Sep 17 00:00:00 2001
+From: Johannes Wiesboeck <johannes.wiesboeck@aisec.fraunhofer.de>
+Date: Tue, 5 Dec 2023 13:18:15 +0100
+Subject: [PATCH] fix uninitialized variables reported by gcc
+
+---
+ src/libcommon/tpm2-common.c | 4 ++--
+ src/provider/provider.c     | 2 +-
+ src/tools/seal_tpm2_data.c  | 1 +
+ 3 files changed, 4 insertions(+), 3 deletions(-)
+
+diff --git a/src/libcommon/tpm2-common.c b/src/libcommon/tpm2-common.c
+index 41a073a..ead306d 100644
+--- a/src/libcommon/tpm2-common.c
++++ b/src/libcommon/tpm2-common.c
+@@ -693,7 +693,7 @@ TPM_RC tpm2_ObjectPublic_GetName(NAME_2B *name,
+ 	TPM_RC rc = 0;
+ 	uint16_t written = 0;
+ 	TPMT_HA digest;
+-	uint32_t sizeInBytes;
++	uint32_t sizeInBytes = 0;
+ 	uint8_t buffer[MAX_RESPONSE_SIZE];
+ 
+ 	/* marshal the TPMT_PUBLIC */
+@@ -1215,7 +1215,7 @@ TPM_RC tpm2_init_session(TSS_CONTEXT *tssContext, TPM_HANDLE handle,
+ 	int num_commands;
+ 	struct policy_command *commands;
+ 	char prefix[128];
+-	TPM_RC rc;
++	TPM_RC rc = TPM_RC_POLICY;
+ 
+ 	if (app_data->pols == NULL)
+ 		return TPM_RC_SUCCESS;
+diff --git a/src/provider/provider.c b/src/provider/provider.c
+index f913bc6..d68034b 100644
+--- a/src/provider/provider.c
++++ b/src/provider/provider.c
+@@ -100,7 +100,7 @@ int OSSL_provider_init(const OSSL_CORE_HANDLE *handle,
+ 		       const OSSL_DISPATCH **out,
+ 		       void **provctx)
+ {
+-	OSSL_LIB_CTX *libctx;
++	OSSL_LIB_CTX *libctx = NULL;
+ 	const OSSL_DISPATCH *fns = in;
+ 	int i;
+ 	OSSL_PARAM provider_params[] = {
+diff --git a/src/tools/seal_tpm2_data.c b/src/tools/seal_tpm2_data.c
+index b0fc5f9..1af0f1b 100644
+--- a/src/tools/seal_tpm2_data.c
++++ b/src/tools/seal_tpm2_data.c
+@@ -362,6 +362,7 @@ int main(int argc, char **argv)
+ 			if (!parent) {
+ 				fprintf(stderr, "Unknown parent '%s'\n",
+ 					parent_str);
++				rc = NOT_TPM_ERROR;
+ 				goto out_flush;
+ 			}
+ 		} else {

--- a/recipes-tss/openssl-tpm2-engine/openssl-tpm2-engine_4.0.1.bb
+++ b/recipes-tss/openssl-tpm2-engine/openssl-tpm2-engine_4.0.1.bb
@@ -20,6 +20,7 @@ SRC_URI = "https://git.kernel.org/pub/scm/linux/kernel/git/jejb/${TAR_N}.git/sna
 	file://Cross-compile-compatible-enginesdir-variable_${PV}.patch \
 	file://Makefile.am-Use-src_topdir-instead-of-relative-inclu_${PV}.patch \
 	file://src-provider-keymgmt-initialize-order-in-tpm2_keymgm_${PV}.patch \
+	file://0001-fix-uninitialized-variables-reported-by-gcc_${PV}.patch \
 "
 
 S = "${WORKDIR}/${TAR_N}-${PV}"


### PR DESCRIPTION
Newer gcc versions complain about uninitialized variables in sbsigntool when compiling with asan. Provide a patch fixing the uninitialized variables.