### PR TITLE
trustx-cml-initramfs: Signed configs in dev builds

### DIFF
--- a/images/trustx-cml.bb
+++ b/images/trustx-cml.bb
@@ -15,5 +15,14 @@ PACKAGE_CLASSES = "package_ipk"
 
 prepare_device_conf () {
     cp "${THISDIR}/${PN}/device.conf" "${WORKDIR}"
+
+    if [ "y" = "${DEVELOPMENT_BUILD}" ];then
+        if [ -z "$(grep 'signed_configs' ${WORKDIR}/device.conf)" ];then
+            bbwarn "Disabling signature enforcement for container configuration in dev build"
+            echo "signed_configs: false" >> ${WORKDIR}/device.conf
+        else
+            bbwarn "Setting for signed_configs already specified, leaving unchanged..."
+        fi
+    fi
 }
 IMAGE_PREPROCESS_COMMAND:append = " prepare_device_conf;"


### PR DESCRIPTION
This commit disables signature enforcement in development builds. This is needed due to the changed default in PR gyroidos/cml#415.