### PR TITLE
images/trustx-cml-initramfs: Deploy kernel before build

### DIFF
--- a/images/trustx-cml-initramfs.bb
+++ b/images/trustx-cml-initramfs.bb
@@ -60,6 +60,7 @@ IMAGE_FEATURES:remove = "package-management"
 
 IMAGE_ROOTFS_SIZE = "4096"
 
+do_rootfs[depends] += "virtual/kernel:do_shared_workdir"
 KERNELVERSION="$(cat "${STAGING_KERNEL_BUILDDIR}/kernel-abiversion")"
 
 update_tabs () {

--- a/images/trustx-cml.bb
+++ b/images/trustx-cml.bb
@@ -2,8 +2,6 @@ inherit image
 
 LICENSE = "GPL-2.0-only"
 
-KERNELVERSION="$(cat "${STAGING_KERNEL_BUILDDIR}/kernel-abiversion")"
-
 DEPENDS += "coreutils-native"
 
 IMAGE_FSTYPES="${TRUSTME_FSTYPES}"


### PR DESCRIPTION
Retrieving the kernel version requires the file
${STAGING_KERNEL_BUILDDIR}/kernel-abiversion to be exist. When the
kernel is checked out from sstate-cache this file is not created.
Forcing the kernel workdir to be deployed fixes this problem.

NB: Other recipes implement this mechanism by inheriting the kernelsrc
class which is similar but puts the dependency on the do_patch task,
that is not available in an image build. Therefore, we implement this by
hand, by manually depending on the do_shared_workdir from the do_rootfs
task.