### PR TITLE
recipes-initscripts/cml-boot: Add missing file for SSH server start

### DIFF
--- a/recipes-initscripts/cml-boot/cml-boot_1.0.bb
+++ b/recipes-initscripts/cml-boot/cml-boot_1.0.bb
@@ -7,6 +7,7 @@ LIC_FILES_CHKSUM = "file://${COREBASE}/meta/COPYING.MIT;md5=3da9cfbcb788c80a0384
 
 SRC_URI = "\
 	file://init_ascii \
+	file://start_sshd \
 	file://cml-boot-script.stub \
 "
 
@@ -45,7 +46,7 @@ do_install() {
 do_install:append () {
 	if [ "y" = "${DEVELOPMENT_BUILD}" ];then
 		bbwarn "Patching /init script to start SSH server in cml layer"
-		sed -i '\|#DEV_START_SSHD#|e cat ${THISDIR}/files/start_sshd' ${D}/init
+		sed -i '\|#DEV_START_SSHD#|e cat ${WORKDIR}/start_sshd' ${D}/init
 	fi
 	sed -i '/#DEV_START_SSHD#/d' ${D}/init
 }

--- a/recipes-initscripts/cml-boot/files/start_sshd
+++ b/recipes-initscripts/cml-boot/files/start_sshd
@@ -1,0 +1,3 @@
+# Prepare and start sshd
+mkdir -p /var/run/sshd
+/usr/sbin/sshd


### PR DESCRIPTION
This file contains the commands to start the openSSH server in the cml layer. If the feature is activated (in dev builds) its contents are copied into the init script.

In previous commits regarding the openSSH integration into the cml layer this file was accidentally not commited resulting in the SSH server not starting at boot. This is hereby fixed.