### PR TITLE
Create buildhistory

### DIFF
--- a/recipes-kernel/linux/linux-vanilla_%.bbappend
+++ b/recipes-kernel/linux/linux-vanilla_%.bbappend
@@ -1,3 +1,7 @@
 include linux-gyroidos.inc
 
 LINUX_VERSION_EXTENSION = "-gyroidos"
+
+# enable buildhistory for this recipe to allow SRCREV extraction
+inherit buildhistory
+BUILDHISTORY_COMMIT = "0"

--- a/recipes-trustx/cmld/cml-common.inc
+++ b/recipes-trustx/cmld/cml-common.inc
@@ -11,6 +11,10 @@ SRC_URI = "git://github.com/gyroidos/cml.git;branch=${BRANCH};protocol=https"
 
 S = "${WORKDIR}/git"
 
+# enable buildhistory for this recipe to allow SRCREV extraction
+inherit buildhistory
+BUILDHISTORY_COMMIT = "0"
+
 DEPENDS:append = " rsync-native"
 
 # Determine if a local checkout of the cml repo is available.


### PR DESCRIPTION
Enable buildhistory in selected recipes to extract the used SRCREV after the build.