### PR TITLE
sc-hsm-embedded: switched to master, commit ee59f6c (Fix bug [...] CCID)

### DIFF
--- a/recipes-sc-hsm-cardservice/sc-hsm-cardservice/sc-hsm-embedded_2.12.bb
+++ b/recipes-sc-hsm-cardservice/sc-hsm-cardservice/sc-hsm-embedded_2.12.bb
@@ -19,8 +19,10 @@ HOMEPAGE = "https://github.com/CardContact/sc-hsm-embedded"
 LICENSE = "BSD-3-Clause"
 LIC_FILES_CHKSUM = "file://COPYING;md5=55b854a477953696452f698a3af5de1c"
 
+SRCREV = "ee59f6c6c9e1dd43a35a413c57a8325209cb4dc6"
 TAG := "${PV}"
-SRC_URI = " git://github.com/CardContact/sc-hsm-embedded.git;protocol=https;tag=V${TAG};branch=master"
+#SRC_URI = " git://github.com/CardContact/sc-hsm-embedded.git;protocol=https;tag=V${TAG};branch=master"
+SRC_URI = " git://github.com/CardContact/sc-hsm-embedded.git;protocol=https;branch=master"
 PV = "${TAG}+git${SRCPV}"
 
 SRC_URI:append = " \


### PR DESCRIPTION
Use current master branch pinned to commit ee59f6c "Fix bug for devices with CCID interface not in first entry of interface list" which allows new tokens from KeyXentics to work properly.