### PR TITLE
conf/templates/default/local.conf.sample: PACKAGECONFIG for

### DIFF
--- a/conf/templates/default/local.conf.sample
+++ b/conf/templates/default/local.conf.sample
@@ -29,6 +29,7 @@ PACKAGECONFIG:append:pn-qemu-native = " sdl"
 PACKAGECONFIG:append:pn-qemu-system-native = " sdl"
 PACKAGECONFIG:append:pn-nativesdk-qemu = " sdl"
 PACKAGECONFIG:pn-btrfs-tools = "programs"
+PACKAGECONFIG:pn-btrfs-tools-native = "programs"
 
 FETCHCMD_wget = "/usr/bin/env wget -t 2 -T 30 --passive-ftp --no-check-certificate"
 KERNEL_DEPLOYSUBDIR = "cml-kernel"


### PR DESCRIPTION
btrfs-progs-native

Recent builds break because btrfs-tools-native enable python features by default without defining the dependency in yocto. Like for the target version, disable the python features for the native build.