### PR TITLE
images/trustx-cml/device.conf: make default update_base_url relative.

### DIFF
--- a/images/trustx-cml/device.conf
+++ b/images/trustx-cml/device.conf
@@ -1,5 +1,5 @@
 uuid: "00000000-0000-0000-0000-000000000000"
-update_base_url: "file://tmp/00000000-0000-0000-0000-000000000000/var/cml-updates"
+update_base_url: "file://var/cml-updates"
 host_addr: "10.0.2.15"
 host_subnet: 24
 host_if: "eth0"


### PR DESCRIPTION
With the new feature of container relative update urls, we should default to the relative path, as this will work more robustly across different setups. Therefore remove the leading tmp/<container_uid> directory.