### PR TITLE
images/trustx-cml: Signature enforcement ccmode

### DIFF
--- a/images/trustx-cml.bb
+++ b/images/trustx-cml.bb
@@ -17,7 +17,7 @@ TRUSTME_DATAPART_LABEL = "trustme"
 prepare_device_conf () {
     cp "${THISDIR}/${PN}/device.conf" "${WORKDIR}"
 
-    if [ "y" = "${DEVELOPMENT_BUILD}" ];then
+    if [ "y" = "${DEVELOPMENT_BUILD}" && "y" != "${CC_MODE}" ];then
         if [ -z "$(grep 'signed_configs' ${WORKDIR}/device.conf)" ];then
             bbwarn "Disabling signature enforcement for container configuration in dev build"
             echo "signed_configs: false" >> ${WORKDIR}/device.conf


### PR DESCRIPTION
This commit skips disabling of signature enforcement if DEVELOPMENT_BUILD and CC_MODE are specified simultaneously for debugging the CML in CC_MODE. This is needed as the cmld in CC_MODE exits as the field 'signed_configs' is not available in CC_MODE.