### PR TITLE
images/trustx-cml/device.conf: enable audit logging

### DIFF
--- a/images/trustx-cml/device.conf
+++ b/images/trustx-cml/device.conf
@@ -4,3 +4,4 @@ host_subnet: 24
 host_if: "eth0"
 host_gateway: "10.0.2.2"
 host_dns: "10.0.2.3"
+audit_size: 50


### PR DESCRIPTION
Added audit_size parameter to enable audit logging by default. Thus, it will be tested if there are any regressions during pull request testing in our Jenkins  pipeline.