### PR TITLE
recipes-initscripts/cml-boot: Adapt core pattern

### DIFF
--- a/recipes-initscripts/cml-boot/cml-boot_1.0.bb
+++ b/recipes-initscripts/cml-boot/cml-boot_1.0.bb
@@ -55,6 +55,7 @@ do_install:append () {
 		bbwarn "Enabling core dumps for debugging purposes"
 		sed -i 's|ulimit -c 0|ulimit -c 102400|' ${D}/init
 		sed -i 's|.*/proc/sys/kernel/core_pattern|mkdir -p /data/core\n&|' ${D}/init
+		sed -i 's|/data/core/%t_core|/data/core/%t_core.%s.%p.%P_%u_%g_%E|' ${D}/init
 	fi
 	sed -i '/#DEV_START_SSHD#/d' ${D}/init
 	sed -i '/#DEV_ENABLE_EXTDATA#/d' ${D}/init

--- a/recipes-initscripts/cml-boot/files/cml-boot-script.stub
+++ b/recipes-initscripts/cml-boot/files/cml-boot-script.stub
@@ -125,7 +125,7 @@ mount -a
 
 #DEV_ENABLE_EXTDATA#
 
-echo "/data/core/%t_core.%s.%p.%P_%u_%g_%E" >> /proc/sys/kernel/core_pattern
+echo "/data/core/%t_core" >> /proc/sys/kernel/core_pattern
 ulimit -c 0
 
 mkdir -p /data/logs


### PR DESCRIPTION
This PR adapts the core dump pattern s.t. in production builds root namspace PIDs of containerized processes are not included in the core dump name.