### PR TITLE
recipes-kernel/linux/linux-gyroidos: added patch for asan builds

### DIFF
--- a/recipes-kernel/linux/generic/0001-tools-lib-subcmd-Fixed-uninitialized-use-of-variable.patch
+++ b/recipes-kernel/linux/generic/0001-tools-lib-subcmd-Fixed-uninitialized-use-of-variable.patch
@@ -1,0 +1,53 @@
+From 299106111dd05e0528be3c2218eafdf3becf2f8d Mon Sep 17 00:00:00 2001
+From: =?UTF-8?q?Michael=20Wei=C3=9F?= <michael.weiss@aisec.fraunhofer.de>
+Date: Wed, 31 Jul 2024 08:27:48 +0200
+Subject: [PATCH] tools lib subcmd: Fixed uninitialized use of variable in
+ parse-options
+MIME-Version: 1.0
+Content-Type: text/plain; charset=UTF-8
+Content-Transfer-Encoding: 8bit
+
+Since commit ea558c86248b ("tools lib subcmd: Show parent options in
+help"), our debug images fail to build.
+
+For our Yocto-based GyroidOS, we build debug images with debugging enabled
+for all binaries including the kernel. Yocto passes the corresponding gcc
+option "-Og" also to the kernel HOSTCFLAGS. This results in the following
+build error:
+
+  parse-options.c: In function ‘options__order’:
+  parse-options.c:834:9: error: ‘o’ may be used uninitialized [-Werror=maybe-uninitialized]
+    834 |         memcpy(&ordered[nr_opts], o, sizeof(*o));
+        |         ^~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
+  parse-options.c:812:30: note: ‘o’ was declared here
+    812 |         const struct option *o, *p = opts;
+        |                              ^
+  ..
+
+Fix it by initializing 'o' instead of 'p' in the above failing line 812.
+'p' is initialized afterwards in the following for-loop anyway.
+I think that was the intention of the commit ea558c86248b ("tools lib
+subcmd: Show parent options in help") in the first place.
+
+Fixes: ea558c86248b ("tools lib subcmd: Show parent options in help")
+Signed-off-by: Michael Weiß <michael.weiss@aisec.fraunhofer.de>
+---
+ tools/lib/subcmd/parse-options.c | 2 +-
+ 1 file changed, 1 insertion(+), 1 deletion(-)
+
+diff --git a/tools/lib/subcmd/parse-options.c b/tools/lib/subcmd/parse-options.c
+index 4b60ec03b0bb..2a3b51a690c7 100644
+--- a/tools/lib/subcmd/parse-options.c
++++ b/tools/lib/subcmd/parse-options.c
+@@ -809,7 +809,7 @@ static int option__cmp(const void *va, const void *vb)
+ static struct option *options__order(const struct option *opts)
+ {
+ 	int nr_opts = 0, nr_group = 0, nr_parent = 0, len;
+-	const struct option *o, *p = opts;
++	const struct option *o = opts, *p;
+ 	struct option *opt, *ordered = NULL, *group;
+ 
+ 	/* flatten the options that have parents */
+-- 
+2.39.2
+

--- a/recipes-kernel/linux/linux-gyroidos.inc
+++ b/recipes-kernel/linux/linux-gyroidos.inc
@@ -1,6 +1,7 @@
 SRC_URI += " \
 	file://0001-video-logo-GyroidOS-specific-logo.patch \
 	file://0001-audit-allow-logging-of-user-events-in-non-initial-na.patch \
+        file://0001-tools-lib-subcmd-Fixed-uninitialized-use-of-variable.patch \
 	file://module_signing.cfg \
 	file://trustx.cfg \
 "


### PR DESCRIPTION
Our asan build sets "-Og" for all packages, including the kernel. Add patch which was submitted upstream to fix uninitialized use of variable in 'tools/lib/subcmd'.