### PR TITLE
Update cml-boot-script.stub to allow TPM2 enabled devices to configure

### DIFF
--- a/recipes-initscripts/cml-boot/files/cml-boot-script.stub
+++ b/recipes-initscripts/cml-boot/files/cml-boot-script.stub
@@ -45,7 +45,7 @@ mount /dev/pts
 echo 1 > /proc/sys/kernel/printk
 
 mkdir -p /dev/shm
-mkdir -p /data
+mkdir -p /data/logs
 
 udevd --daemon
 scan_devices


### PR DESCRIPTION
tmp2d looks to open log files in `/data/logs` When the logs folder is not present, `tpm2d` segfaults and crashes a freshly installed OS.  This only happens when a TPM2 is enabled and present.  Moving the `mkdir` of `/data/logs` up ahead of where the `tpm2d -n` is launched to allow for a successful boot.