### PR TITLE
recipes-kernel/linux/linux-vanilla: remove kbuild truncate dependency

### DIFF
--- a/recipes-kernel/linux/linux-vanilla/0001-kbuild-remove-recent-dependency-on-truncate-program.patch
+++ b/recipes-kernel/linux/linux-vanilla/0001-kbuild-remove-recent-dependency-on-truncate-program.patch
@@ -1,0 +1,34 @@
+From 14cca8fcbafcb9922d32b4dd62cbe2b82a462e5a Mon Sep 17 00:00:00 2001
+From: Tony Battersby <tonyb@cybernetics.com>
+Date: Thu, 29 Aug 2024 09:51:25 -0400
+Subject: [PATCH] kbuild: remove recent dependency on "truncate" program
+
+Remove the recently-added dependency on the truncate program for
+building the kernel. truncate is not available when building the kernel
+under Yocto. It could be added, but it would be better just to avoid
+the unnecessary dependency.
+
+Fixes: 1472464c6248 ("kbuild: avoid scripts/kallsyms parsing /dev/null")
+Signed-off-by: Tony Battersby <tonyb@cybernetics.com>
+Reviewed-by: Nathan Chancellor <nathan@kernel.org>
+Signed-off-by: Masahiro Yamada <masahiroy@kernel.org>
+---
+ scripts/link-vmlinux.sh | 2 +-
+ 1 file changed, 1 insertion(+), 1 deletion(-)
+
+diff --git a/scripts/link-vmlinux.sh b/scripts/link-vmlinux.sh
+index 070a319140e8..c27b4e969f20 100755
+--- a/scripts/link-vmlinux.sh
++++ b/scripts/link-vmlinux.sh
+@@ -215,7 +215,7 @@ kallsymso=
+ strip_debug=
+ 
+ if is_enabled CONFIG_KALLSYMS; then
+-	truncate -s0 .tmp_vmlinux.kallsyms0.syms
++	true > .tmp_vmlinux.kallsyms0.syms
+ 	kallsyms .tmp_vmlinux.kallsyms0.syms .tmp_vmlinux0.kallsyms
+ fi
+ 
+-- 
+2.39.2
+

--- a/recipes-kernel/linux/linux-vanilla_%.bbappend
+++ b/recipes-kernel/linux/linux-vanilla_%.bbappend
@@ -8,6 +8,7 @@ BUILDHISTORY_COMMIT = "0"
 
 SRC_URI += "\
         file://0001-ipvs-allow-netlink-configuration-from-non-initial-us.patch \
+        file://0001-kbuild-remove-recent-dependency-on-truncate-program.patch \
 "
 
 FILESEXTRAPATHS:prepend := "${THISDIR}/${PN}:"


### PR DESCRIPTION
Added 0001-kbuild-remove-recent-dependency-on-truncate-program.patch which allows to build the current rolling stable kernel in yocto. This patch is already in the kbuild tree for-next. Thus we need to remove this again when rolling stable hits this.