### PR TITLE
images/trustx-cml: Skip signed_configs in CC_MODE

### DIFF
--- a/images/trustx-cml.bb
+++ b/images/trustx-cml.bb
@@ -17,7 +17,7 @@ TRUSTME_DATAPART_LABEL = "trustme"
 prepare_device_conf () {
     cp "${THISDIR}/${PN}/device.conf" "${WORKDIR}"
 
-    if [ "y" = "${DEVELOPMENT_BUILD}" ];then
+    if [ "y" = "${DEVELOPMENT_BUILD}" ] &&  [ "n" = "${CC_MODE}" ];then
         if [ -z "$(grep 'signed_configs' ${WORKDIR}/device.conf)" ];then
             bbwarn "Disabling signature enforcement for container configuration in dev build"
             echo "signed_configs: false" >> ${WORKDIR}/device.conf


### PR DESCRIPTION
This commit adapts prepare_device_conf() s.t. "signed_configs: false" is only set if CC_MODE is disabled. This is necessary becaus the CML already enforces this setting in CC_MODE leading to integration test errors if specified.