### PR TITLE
initscripts/poky: switch back to fstab mounting with 'mount -a'

### DIFF
--- a/recipes-initscripts/cml-boot/files/cml-boot-script.stub
+++ b/recipes-initscripts/cml-boot/files/cml-boot-script.stub
@@ -124,28 +124,14 @@ else
 	#DEV_MOUNT_PLAIN_CML_PART#
 fi
 
-mount -o bind,nosuid,nodev,noexec /mnt/userdata /data
+mount -a
 
 #DEV_ENABLE_EXTFS#
-
-mkdir -p /boot
-mount /boot
-
-mount /lib/modules
-mount /lib/firmware
-
-mkdir -p /tmp
-mount /tmp
-
-mkdir -p /var/volatile
-mount /var/volatile
-
-mkdir -p /var/volatile/tmp
-
 
 echo "/data/core/%t_core" >> /proc/sys/kernel/core_pattern
 ulimit -c 0
 
+mount -o bind,nosuid,nodev,noexec /mnt/userdata /data
 mkdir -p /data/logs
 
 #now modules partition is mounted
@@ -159,6 +145,10 @@ modprobe loop
 modprobe btrfs
 modprobe vport-gre
 modprobe cfg80211
+
+mount -a
+
+mkdir -p /var/volatile/tmp
 
 for suffix in conf sig cert; do
 	if [ ! -f "/data/cml/containers/00000000-0000-0000-0000-000000000000.$suffix" ]; then

--- a/recipes-poky/base-files/base-files/fstab
+++ b/recipes-poky/base-files/base-files/fstab
@@ -3,17 +3,14 @@
 proc                 /proc                proc       nosuid,nodev,noexec   0  0
 sysfs                /sys                 sysfs      nosuid,nodev,noexec   0  0
 devtmpfs             /dev                 devtmpfs   mode=0755,nosuid      0  0
-tmpfs                /run                 tmpfs      mode=0755,nodev,nosuid,strictatime 0  0
-
 devpts               /dev/pts             devpts     mode=0620,gid=5       0  0
+tmpfs                /run                 tmpfs      mode=0755,nodev,nosuid,strictatime 0  0
+tmpfs                /var/volatile        tmpfs      nosuid,nodev,noexec   0  0
 
 tmpfs                /tmp                 tmpfs      defaults              0  0
 
-tmpfs                /var/volatile        tmpfs      nosuid,nodev,noexec   0  0
-
-
 LABEL=boot           /boot                vfat       umask=0077            0  1
-#LABEL=trustme        /mnt                 ext4       nosuid,nodev,noexec   0  0
-#
+LABEL=trustme        /mnt                 ext4       nosuid,nodev,noexec   0  0
+
 /mnt/modules.img     /lib/modules         squashfs   loop,nosuid,nodev,noexec 0  0
 /mnt/firmware.img    /lib/firmware        squashfs   loop,nosuid,nodev,noexec 0  0


### PR DESCRIPTION
Currently, booting is instable, thus we switch back to fstab based mounting with 'mount -a' in the cml-init script.
This partially reverts commit 49f7e0cf4c326dccd13ea378ecb657ade35ef3bd ("initscripts/poky: Restructure fs mounting").