### PR TITLE
initscripts/poky: do not over mount '/data' if already mounted

### DIFF
--- a/recipes-initscripts/cml-boot/files/cml-boot-script.stub
+++ b/recipes-initscripts/cml-boot/files/cml-boot-script.stub
@@ -131,7 +131,12 @@ mount -a
 echo "/data/core/%t_core" >> /proc/sys/kernel/core_pattern
 ulimit -c 0
 
-mount -o bind,nosuid,nodev,noexec /mnt/userdata /data
+# check if data is already mounted by debugging feature or fstab
+mountpoint /data
+if [ $? -ne 0 ]; then
+	mount -o bind,nosuid,nodev,noexec /mnt/userdata /data
+fi
+
 mkdir -p /data/logs
 
 #now modules partition is mounted


### PR DESCRIPTION
In case of /data is already mounted by debugging feature including extdata and containers mountpoints, bind mount or overlay mounts are already set up. Thus, the bind mount from /mnt/userdata to /data in cm-boot-script.stub would over mount this again. Fix this by just checking if /data is already mounted with 'mountpoint'.

Fixes: ee0cbe220b4a ("initscripts/poky: switch back to fstab mounting with 'mount -a'")