### PR TITLE
treewide: Implement PKCS#11 URI checking using helper function

### DIFF
--- a/classes/p11-signing.bbclass
+++ b/classes/p11-signing.bbclass
@@ -20,6 +20,14 @@ extract_cert () {
         p11tool --provider ${PKCS11_MODULE_PATH} --export-chain $1 > $2
 }
 
+is_pkcs11_uri () {
+	if [ "${1#pkcs11:}" != "${1}" ]; then
+	    return 0 # this is TRUE in shell script. trust|me i know
+	else
+	    return 1
+	fi
+}
+
 # variables passed to OpenSSL
 export OPENSSL_ENGINES = "${RECIPE_SYSROOT_NATIVE}/usr/lib/engines-3"
 export PKCS11_MODULE_PATH

--- a/classes/trustmegeneric.bbclass
+++ b/classes/trustmegeneric.bbclass
@@ -28,8 +28,7 @@ install_ssig_rootca () {
 		bbfatal "GUESTOS_SIG_ROOT_CERT is not set. Set GUESTOS_SIG_ROOT_CERT in local.conf."
 	fi
 
-	if [[ "${GUESTOS_SIG_ROOT_CERT}" == pkcs11:* ]] # BASH-if on purpose
-	then
+	if is_pkcs11_uri ${GUESTOS_SIG_ROOT_CERT}; then
 		extract_cert "${GUESTOS_SIG_ROOT_CERT}" "${rootfs_datadir}/cml/tokens/ssig_rootca.cert"
 	else
 		if ! [ -f "${GUESTOS_SIG_ROOT_CERT}" ];then

--- a/images/trustx-cml-firmware.bb
+++ b/images/trustx-cml-firmware.bb
@@ -21,15 +21,13 @@ move_firmware() {
 	mv ${IMAGE_ROOTFS}/lib/firmware/* ${IMAGE_ROOTFS}/
 
 	certpath="${FIRMWARE_SIG_CERT}"
-	if [[ "${FIRMWARE_SIG_CERT}" == pkcs11:* ]] # BASH-if on purpose
-	then
+	if is_pkcs11_uri ${FIRMWARE_SIG_CERT}; then
 		certpath="${WORKDIR}/FIRMWARE_SIG_CERT"
 		extract_cert "${FIRMWARE_SIG_CERT}" "${certpath}.pem"
 		openssl x509 -in "${certpath}.pem" -outform DER -out "${certpath}.der"
 	fi
 
-	if [[ "${FIRMWARE_SIG_KEY}" == pkcs11:* ]] # BASH-if on purpose
-	then
+	if is_pkcs11_uri ${FIRMWARE_SIG_KEY}; then
 		evmctl ima_sign -r --hashalgo sha256 --engine pkcs11 --key "${FIRMWARE_SIG_KEY}" --keyid-from-cert "${certpath}.der" "${IMAGE_ROOTFS}/"
 	else
 		evmctl ima_sign -r --hashalgo sha256 --key "${FIRMWARE_SIG_KEY}" "${IMAGE_ROOTFS}/"

--- a/images/trustx-cml-initramfs.bb
+++ b/images/trustx-cml-initramfs.bb
@@ -92,8 +92,7 @@ install_ima_cert () {
 
 	mkdir -p ${IMAGE_ROOTFS}/etc/keys
 
-	if [[ "${FIRMWARE_SIG_CERT}" == pkcs11:* ]] # BASH-if on purpose
-	then
+	if is_pkcs11_uri ${FIRMWARE_SIG_CERT}; then
 		extract_cert "${FIRMWARE_SIG_CERT}" "${WORKDIR}/FIRMWARE_SIG_CERT.pem"
 		openssl x509 -in "${WORKDIR}/FIRMWARE_SIG_CERT.pem" -outform DER -out "${IMAGE_ROOTFS}/etc/keys/x509_ima.der"
 	else

--- a/recipes-kernel/linux/linux-gyroidos.inc
+++ b/recipes-kernel/linux/linux-gyroidos.inc
@@ -28,8 +28,7 @@ kernel_do_configure:prepend() {
 
 	# if KERNEL_SYSTEM_TRUSTED_KEYS is a pkcs#11 URI, extract the certificate
 	if [ "" != "${KERNEL_SYSTEM_TRUSTED_KEYS}" ]; then
-		if [[ "${KERNEL_SYSTEM_TRUSTED_KEYS}" == pkcs11:* ]] # BASH-if on purpose
-		then
+		if is_pkcs11_uri ${KERNEL_SYSTEM_TRUSTED_KEYS}; then
 			extract_cert "${KERNEL_SYSTEM_TRUSTED_KEYS}" "${WORKDIR}/KERNEL_SYSTEM_TRUSTED_KEYS.pem"
 			sed -i '/^CONFIG_SYSTEM_TRUSTED_KEYS=/{h;s|=.*|="${WORKDIR}/KERNEL_SYSTEM_TRUSTED_KEYS.pem"|};${x;/^$/{s||CONFIG_SYSTEM_TRUSTED_KEYS="${WORKDIR}/KERNEL_SYSTEM_TRUSTED_KEYS.pem"|;H};x}' ${B}/.config
 		else


### PR DESCRIPTION
Checking if a Yocto variable starts with "pkcs11:" in POSIX compliant shell turns out to be complicated. Implement a helper function in p11-signing.bbclass.