### PR TITLE
recipes-tss/openssl-tpm2-engine: added 32bit compat patch

### DIFF
--- a/recipes-tss/openssl-tpm2-engine/openssl-tpm2-engine/Fix-32-bit-errors_4.3.0.patch
+++ b/recipes-tss/openssl-tpm2-engine/openssl-tpm2-engine/Fix-32-bit-errors_4.3.0.patch
@@ -1,0 +1,32 @@
+From 508060a88b6e928b534a53bc0363d1017babc94e Mon Sep 17 00:00:00 2001
+From: James Bottomley <James.Bottomley@HansenPartnership.com>
+Date: Fri, 1 Nov 2024 17:49:22 -0500
+Subject: [PATCH] Fix 32 bit errors
+
+One formatting problem with UINT64 and a must check annotation on
+read that only seems to exist in the 32 bit builds.
+
+Signed-off-by: James Bottomley <James.Bottomley@HansenPartnership.com>
+---
+ src/tools/attest_tpm2_primary.c | 5 +++--
+ 1 file changed, 3 insertions(+), 2 deletions(-)
+
+diff --git a/src/tools/attest_tpm2_primary.c b/src/tools/attest_tpm2_primary.c
+index 3acd511..8b14f6b 100644
+--- a/src/tools/attest_tpm2_primary.c
++++ b/src/tools/attest_tpm2_primary.c
+@@ -416,8 +416,9 @@ void do_certify(const char *auth, TPM_HANDLE handle, const char *namefile,
+ 		tpm2_get_hexname(hexname, &pubh);
+ 		printf("%s\n", hexname);
+ 	} else {
+-		printf("Good certification from TPM at %lu.%04d reset count %u\n",
+-		       a.clockInfo.clock/1000, (int)(a.clockInfo.clock%1000),
++		printf("Good certification from TPM at %llu.%04d reset count %u\n",
++		       (unsigned long long)a.clockInfo.clock/1000,
++		       (int)(a.clockInfo.clock%1000),
+ 		       a.clockInfo.resetCount);
+ 	}
+ 	rc = 0;
+-- 
+2.39.5
+

--- a/recipes-tss/openssl-tpm2-engine/openssl-tpm2-engine_4.3.0.bb
+++ b/recipes-tss/openssl-tpm2-engine/openssl-tpm2-engine_4.3.0.bb
@@ -22,6 +22,7 @@ SRC_URI = "https://git.kernel.org/pub/scm/linux/kernel/git/jejb/${TAR_N}.git/sna
 	file://src-provider-keymgmt-initialize-order-in-tpm2_keymgm_${PV}.patch \
 	file://0001-fix-uninitialized-variables-reported-by-gcc_${PV}.patch \
 	file://Do-not-use-deprecated-ibmtss-functions_${PV}.patch \
+	file://Fix-32-bit-errors_${PV}.patch \
 "
 
 S = "${WORKDIR}/${TAR_N}-${PV}"


### PR DESCRIPTION
Recent update to 4.3.0 did not compile on 32bit arch. Thus, added backport of upstream commit 508060a88b6e ("Fix 32 bit errors").

Fixes: d8b99868876a ("recipes-tss/openssl-tpm2-engine: updated to version 4.3.0")