### PR TITLE
recipes-trustx/userdata/pki-native: Allow key size override

### DIFF
--- a/recipes-gyroidos/userdata/pki-native.bb
+++ b/recipes-gyroidos/userdata/pki-native.bb
@@ -19,10 +19,13 @@ inherit native
 
 SSTATE_SKIP_CREATION = "1"
 
+PKI_KEY_SIZE ?= "4096"
+
 do_compile() {
     if [ ! -f ${TEST_CERT_DIR}.generating ]; then
         touch ${TEST_CERT_DIR}.generating
         export DO_PLATFORM_KEYS=${PKI_UEFI_KEYS}
+        export KEY_SIZE=${PKI_KEY_SIZE}
         bash ${PROVISIONING_DIR}/gen_dev_certs.sh ${TEST_CERT_DIR}
         if [ ! -d ${TEST_CERT_DIR}/certs ]; then
             mkdir -p ${TEST_CERT_DIR}/certs


### PR DESCRIPTION
To set the appropriate key size for (e.g. RPi 4, 2048 bit only) secure boot mechanisms, set the default key size to 4096 bit but allow setting overriding the key size in a device config file.

test with: https://github.com/gyroidos/gyroidos_build/pull/121