### PR TITLE
recipes-trustx/cmld: make host configurable

### DIFF
--- a/recipes-trustx/cmld/cml-common.inc
+++ b/recipes-trustx/cmld/cml-common.inc
@@ -1,7 +1,7 @@
 LICENSE = "GPL-2.0-only"
 LIC_FILES_CHKSUM = "file://${S}/COPYING;md5=b234ee4d69f5fce4486a80fdaf4a4263"
 
-BRANCH = "kirkstone"
+BRANCH = "main"
 SRCREV = "${AUTOREV}"
 
 PVBASE := "${PV}"

--- a/recipes-trustx/cmld/cml-common.inc
+++ b/recipes-trustx/cmld/cml-common.inc
@@ -7,7 +7,9 @@ SRCREV = "${AUTOREV}"
 PVBASE := "${PV}"
 PV = "${PVBASE}+${SRCPV}"
 
-SRC_URI = "git://github.com/gyroidos/cml.git;branch=${BRANCH};protocol=https"
+CML_HOST ?= "github.com/gyroidos"
+
+SRC_URI = "git://${CML_HOST}/cml.git;branch=${BRANCH};protocol=https"
 
 S = "${WORKDIR}/git"
 


### PR DESCRIPTION
To make remotes configurable we moved the host part of the uri to a separate variable called CML_HOST.