### PR TITLE
conf: add distros files cml-base, core-ref

### DIFF
--- a/conf/distro/cml-base.conf
+++ b/conf/distro/cml-base.conf
@@ -1,0 +1,9 @@
+require conf/distro/poky-tiny.conf
+DISTRO = "cml-base"
+DISTRO_NAME = "GyroidOS CML (CML Base Distribution)"
+DISTRO_VERSION:prepend = "0.9-"
+MAINTAINER = "GyroidOS <gyroidos@aisec.fraunhofer.de>"
+DISTROOVERRIDES = "poky-tiny:cml-base"
+TARGET_VENDOR = "-gyroidos"
+
+INITRAMFS_MAXSIZE = '${@oe.utils.vartrue('DEVELOPMENT_BUILD', "200000", "150000", d)}'

--- a/conf/distro/core-ref.conf
+++ b/conf/distro/core-ref.conf
@@ -1,0 +1,7 @@
+require conf/distro/poky.conf
+DISTRO = "core-ref"
+DISTRO_NAME = "GyroidOS Core (Core Reference Distro)"
+DISTRO_VERSION:prepend = "0.9-"
+MAINTAINER = "GyroidOS <gyroidos@aisec.fraunhofer.de>"
+DISTROOVERRIDES = "poky:core-ref"
+TARGET_VENDOR = "-gyroidos"


### PR DESCRIPTION
Last commit missed the actual new distro files for cml-base and core-ref. Add them now.

Fixes: b5299ba2f996 ("conf: renamed distros gyroidos-{cml,core} to cml-base, core-ref")