### PR TITLE
conf/multiconfig: set linux-dummy for core-ref for qemuarm

### DIFF
--- a/conf/multiconfig/container_qemuarm.inc
+++ b/conf/multiconfig/container_qemuarm.inc
@@ -17,7 +17,7 @@ CONF_VERSION = "2"
 MACHINE = "qemuarm"
 
 PREFERRED_PROVIDER_virtual/kernel = "linux-dummy"
-PREFERRED_PROVIDER_virtual/kernel:gyroidos-core = "linux-dummy"
+PREFERRED_PROVIDER_virtual/kernel:core-ref = "linux-dummy"
 PREFERRED_PROVIDER_virtual/kernel:linuxstdbase = "linux-dummy"
 
 KERNEL_DEVICETREE = ""

--- a/conf/multiconfig/container_qemuarm64.inc
+++ b/conf/multiconfig/container_qemuarm64.inc
@@ -17,7 +17,7 @@ CONF_VERSION = "2"
 MACHINE = "qemuarm64"
 
 PREFERRED_PROVIDER_virtual/kernel = "linux-dummy"
-PREFERRED_PROVIDER_virtual/kernel:gyroidos-core = "linux-dummy"
+PREFERRED_PROVIDER_virtual/kernel:core-ref = "linux-dummy"
 PREFERRED_PROVIDER_virtual/kernel:linuxstdbase = "linux-dummy"
 
 KERNEL_DEVICETREE = ""


### PR DESCRIPTION
In container_qemuarm*.inc linux-dummy were set as preferred kernel provider for the gyroidos-core distro. However this was renamed to core-ref. Thus, also set linux-dummy for the core-ref distro and not gyroidos-core anymore.

Fixes: b5299ba2f996 ("conf: renamed distros gyroidos-{cml,core} to cml-base, core-ref")